### PR TITLE
Dev

### DIFF
--- a/builtin/builtin/arldm/README.md
+++ b/builtin/builtin/arldm/README.md
@@ -215,8 +215,7 @@ module load arldm
 
 Store the current environment in the pipeline.
 ```bash
-jarvis pipeline env build
-jarvis pipeline env scan +PRETRAIN_MODEL_PATH +EXPERIMENT_INPUT_PATH +ARLDM_PATH
+jarvis pipeline env build +PRETRAIN_MODEL_PATH +EXPERIMENT_INPUT_PATH +ARLDM_PATH
 ```
 
 ## 2.6. Add pkgs to the Pipeline
@@ -334,7 +333,7 @@ jarvis pipeline create hermes_arldm_test
 
 Store the current environment in the pipeline.
 ```bash
-jarvis pipeline env build
+jarvis pipeline env build +PRETRAIN_MODEL_PATH +EXPERIMENT_INPUT_PATH +ARLDM_PATH
 ```
 
 ## 4.5. Add pkgs to the Pipeline
@@ -411,7 +410,7 @@ module load arldm
 
 Store the current environment in the pipeline.
 ```bash
-jarvis pipeline env build
+jarvis pipeline env build +PRETRAIN_MODEL_PATH +EXPERIMENT_INPUT_PATH +ARLDM_PATH
 ```
 
 

--- a/builtin/builtin/arldm/README.md
+++ b/builtin/builtin/arldm/README.md
@@ -102,10 +102,11 @@ Currently setup input path in a shared storage, below is a example on Ares clust
 Setup experiment input and ouput paths:
 ```bash
 EXPERIMENT_PATH=~/experiments/arldm_run
-EXPERIMENT_INPUT_PATH=$EXPERIMENT_PATH/input_data
-EXPERIMENT_OUTPUT_PATH=$EXPERIMENT_PATH/output_data
+export EXPERIMENT_INPUT_PATH=$EXPERIMENT_PATH/input_data
 
-mkdir -p $EXPERIMENT_INPUT_PATH $EXPERIMENT_OUTPUT_PATH $EXPERIMENT_INPUT_PATH/zippack
+scspkg env set arldm EXPERIMENT_INPUT_PATH=$EXPERIMENT_INPUT_PATH
+
+mkdir -p $EXPERIMENT_INPUT_PATH $EXPERIMENT_INPUT_PATH/zippack
 ```
 
 ## 2.2. Download Pretrain Model
@@ -215,6 +216,7 @@ module load arldm
 Store the current environment in the pipeline.
 ```bash
 jarvis pipeline env build
+jarvis pipeline env scan +PRETRAIN_MODEL_PATH +EXPERIMENT_INPUT_PATH +ARLDM_PATH
 ```
 
 ## 2.6. Add pkgs to the Pipeline
@@ -339,7 +341,7 @@ jarvis pipeline env build
 
 Create a Jarvis pipeline with Hermes, using the Hermes POSIX interceptor.
 ```bash
-jarvis pipeline append hermes_run --sleep=10 include=$EXPERIMENT_OUTPUT_PATH/${RUN_SCRIPT}_out.h5
+jarvis pipeline append hermes_run --sleep=10 include=$EXPERIMENT_INPUT_PATH/${RUN_SCRIPT}_out.h5
 jarvis pipeline append hermes_api +posix
 jarvis pipeline append arldm runscript=vistsis arldm_path="`scspkg pkg src arldm`/ARLDM" update_envar=true
 ```
@@ -378,12 +380,11 @@ Currently setup DEFAULT input path in a shared storage, below is a example on Ar
 ```bash
 RUN_SCRIPT=vistsis # can change to other datasets
 EXPERIMENT_PATH=~/experiments/arldm_run # NFS
-INPUT_PATH=$EXPERIMENT_PATH/input_data # NFS
+SHARED_INPUT_PATH=$EXPERIMENT_PATH/input_data # NFS
 cd $EXPERIMENT_PATH; export PRETRAIN_MODEL_PATH=`realpath model_large.pth`
 
 LOCAL_EXPERIMENT_PATH=/mnt/nvme/$USER/arldm_run
 LOCAL_INPUT_PATH=$LOCAL_EXPERIMENT_PATH/input_data
-LOCAL_OUTPUT_PATH=$LOCAL_EXPERIMENT_PATH/output_data
 ```
 
 ## 5.2. Download Pretrain Model and Input Data
@@ -419,16 +420,16 @@ Add data_stagein to pipeline before arldm.
 - For `RUN_SCRIPT=vistsis` you need to stage in three different input directories:
 ```bash 
 jarvis pipeline append data_stagein dest_data_path=$LOCAL_INPUT_PATH \
-user_data_paths=$INPUT_PATH/vistdii,$INPUT_PATH/vistsis,$INPUT_PATH/visit_img,$PRETRAIN_MODEL_PATH \
-mkdir_datapaths=$LOCAL_INPUT_PATH,$LOCAL_OUTPUT_PATH
+user_data_paths=$SHARED_INPUT_PATH/vistdii,$SHARED_INPUT_PATH/vistsis,$SHARED_INPUT_PATH/visit_img,$PRETRAIN_MODEL_PATH \
+mkdir_datapaths=$LOCAL_INPUT_PATH
 ```
 
 - For other `RUN_SCRIPT`, you only need to stagein one directory:
 ```bash 
 RUN_SCRIPT=pororo
 jarvis pipeline append data_stagein dest_data_path=$LOCAL_INPUT_PATH \
-user_data_paths=$INPUT_PATH/$RUN_SCRIPT \
-mkdir_datapaths=$LOCAL_INPUT_PATH,$LOCAL_OUTPUT_PATH
+user_data_paths=$SHARED_INPUT_PATH/$RUN_SCRIPT \
+mkdir_datapaths=$LOCAL_INPUT_PATH
 ```
 
 
@@ -460,19 +461,18 @@ Every step the same as [ARLDM + Hermes](#4-arldm-with-hermes), except for when c
 # Setup env
 RUN_SCRIPT=vistsis # can change to other datasets
 EXPERIMENT_PATH=~/experiments/arldm_run # NFS
-INPUT_PATH=$EXPERIMENT_PATH/input_data # NFS
+SHARED_INPUT_PATH=$EXPERIMENT_PATH/input_data # NFS
 cd $EXPERIMENT_PATH; export PRETRAIN_MODEL_PATH=`realpath model_large.pth`
 
 LOCAL_EXPERIMENT_PATH=/mnt/nvme/$USER/arldm_run
 LOCAL_INPUT_PATH=$LOCAL_EXPERIMENT_PATH/input_data
-LOCAL_OUTPUT_PATH=$LOCAL_EXPERIMENT_PATH/output_data
 
 # add pkg to pipeline
 jarvis pipeline append data_stagein dest_data_path=$LOCAL_INPUT_PATH \
-user_data_paths=$INPUT_PATH/vistdii,$INPUT_PATH/vistsis,$INPUT_PATH/visit_img,$PRETRAIN_MODEL_PATH \
-mkdir_datapaths=$LOCAL_INPUT_PATH,$LOCAL_OUTPUT_PATH
+user_data_paths=$SHARED_INPUT_PATH/vistdii,$SHARED_INPUT_PATH/vistsis,$SHARED_INPUT_PATH/visit_img,$PRETRAIN_MODEL_PATH \
+mkdir_datapaths=$LOCAL_INPUT_PATH
 
-jarvis pipeline append hermes_run --sleep=10 include=$LOCAL_OUTPUT_PATH/${RUN_SCRIPT}_out.h5
+jarvis pipeline append hermes_run --sleep=10 include=$LOCAL_INPUT_PATH/${RUN_SCRIPT}_out.h5
 
 jarvis pipeline append hermes_api +posix
 

--- a/builtin/builtin/arldm/README.md
+++ b/builtin/builtin/arldm/README.md
@@ -435,7 +435,7 @@ mkdir_datapaths=$LOCAL_INPUT_PATH
 
 Create a Jarvis pipeline with ARLDM.
 ```bash
-jarvis pipeline append arldm runscript=$RUN_SCRIPT arldm_path="`scspkg pkg src arldm`/ARLDM" local_exp_dir=$LOCAL_EXPERIMENT_PATH
+jarvis pipeline append arldm runscript=$RUN_SCRIPT arldm_path="`scspkg pkg src arldm`/ARLDM" local_exp_dir=$LOCAL_INPUT_PATH
 ```
 
 ## 5.7. Run the Experiment
@@ -476,7 +476,7 @@ jarvis pipeline append hermes_run --sleep=10 include=$LOCAL_INPUT_PATH/${RUN_SCR
 
 jarvis pipeline append hermes_api +posix
 
-jarvis pipeline append arldm runscript=vistsis arldm_path="`scspkg pkg src arldm`/ARLDM" update_envar=true local_exp_dir=$LOCAL_EXPERIMENT_PATH
+jarvis pipeline append arldm runscript=vistsis arldm_path="`scspkg pkg src arldm`/ARLDM" update_envar=true local_exp_dir=$LOCAL_INPUT_PATH
 ```
 
 

--- a/builtin/builtin/arldm/README.md
+++ b/builtin/builtin/arldm/README.md
@@ -221,18 +221,12 @@ jarvis pipeline env build +PRETRAIN_MODEL_PATH +EXPERIMENT_INPUT_PATH +ARLDM_PAT
 ## 2.6. Add pkgs to the Pipeline
 Create a Jarvis pipeline with ARLDM.
 ```bash
-jarvis pipeline append arldm runscript=vistsis arldm_path="`scspkg pkg src arldm`/ARLDM"
+jarvis pipeline append arldm runscript=vistsis
 ```
-
-<!-- ```bash
-jarvis pipeline append arldm conda_env=arldm runscript=vistsis arldm_path="`scspkg pkg src arldm`/ARLDM"
-
-jarvis pkg configure arldm conda_env=arldm runscript=run_mcs_tbpfradar3d_wrf config=${HOME}/jarvis-cd/builtin/builtin/arldm/example_config/config_template.yml
-``` -->
 
 ## 2.7. Run Experiment
 
-Run the experiment
+Run the experiment, output are generated in `$EXPERIMENT_INPUT_PATH/output_data`.
 ```bash
 jarvis pipeline run
 ```
@@ -342,25 +336,15 @@ Create a Jarvis pipeline with Hermes, using the Hermes POSIX interceptor.
 ```bash
 jarvis pipeline append hermes_run --sleep=10 include=$EXPERIMENT_INPUT_PATH/${RUN_SCRIPT}_out.h5
 jarvis pipeline append hermes_api +posix
-jarvis pipeline append arldm runscript=vistsis arldm_path="`scspkg pkg src arldm`/ARLDM" update_envar=true
+jarvis pipeline append arldm runscript=vistsis update_envar=true
 ```
 
-## 4.6. Run the Experiment (TODO)
+## 4.6. Run the Experiment
 
-Run the experiment
+Run the experiment, output are generated in `$EXPERIMENT_INPUT_PATH/output_data`.
 ```bash
 jarvis pipeline run
 ```
-Currently the script runs with error when entering the training.
-
-<!-- Error when using Hermes VFD:
-```log
-Global seed set to 0
-/home/mtang11/downloads/hermes-1.0.0/hrun/include/hrun/api/manager.h:78 158882 LoadServerConfig Loading server configuration: /home/mtang11/jarvis-pipelines/dhm_arldm/hermes_run/hermes_server.yaml
-/tmp/tmp2a22oj34: line 3: 158882 Aborted                 (core dumped) python /mnt/common/mtang11/scripts/scspkg/packages/arldm/src/ARLDM/main.py
-
-ERROR conda.cli.main_run:execute(49): `conda run python /mnt/common/mtang11/scripts/scspkg/packages/arldm/src/ARLDM/main.py` failed. (See above for error)
-``` -->
 
 ## 4.7. Clean Data
 
@@ -434,12 +418,12 @@ mkdir_datapaths=$LOCAL_INPUT_PATH
 
 Create a Jarvis pipeline with ARLDM.
 ```bash
-jarvis pipeline append arldm runscript=$RUN_SCRIPT arldm_path="`scspkg pkg src arldm`/ARLDM" local_exp_dir=$LOCAL_INPUT_PATH
+jarvis pipeline append arldm runscript=$RUN_SCRIPT local_exp_dir=$LOCAL_INPUT_PATH
 ```
 
 ## 5.7. Run the Experiment
 
-Run the experiment
+Run the experiment, output are generated in `$LOCAL_INPUT_PATH/output_data`.
 ```bash
 jarvis pipeline run
 ```

--- a/builtin/builtin/arldm/pkg.py
+++ b/builtin/builtin/arldm/pkg.py
@@ -153,7 +153,7 @@ class Arldm(Application):
                 experiment_input_path = self.config['experiment_input_path']
                 if self.config['local_exp_dir'] is not None:
                     experiment_input_path = self.config['local_exp_dir']
-                    self.config['ckpt_dir'] = experiment_input_path + "/save_ckpt"
+                    self.config['ckpt_dir'] = experiment_input_path + f"/{self.config['runscript']}_save_ckpt"
                     self.config['sample_output_dir'] = experiment_input_path + f"/sample_out_{self.config['runscript']}_{self.config['mode']}"
                     self.config['hdf5_file'] = f"{experiment_input_path}/{self.config['runscript']}_out.h5"
 
@@ -226,7 +226,7 @@ class Arldm(Application):
         pathlib.Path(self.config['experiment_input_path']).mkdir(parents=True, exist_ok=True)
         
         # set ckpt_dir
-        self.config['ckpt_dir'] = f'{self.config["experiment_input_path"]}/save_ckpt'
+        self.config['ckpt_dir'] = f'{self.config["experiment_input_path"]}/{self.config["runscript"]}_save_ckpt'
         pathlib.Path(self.config['ckpt_dir']).mkdir(parents=True, exist_ok=True)
         
         # set sample_output_dir
@@ -247,7 +247,7 @@ class Arldm(Application):
         if self.config['local_exp_dir'] is not None:
             experiment_input_path = self.config['local_exp_dir']
 
-        self.log(f"ARLDM _prep_hdf5_file input from {experiment_input_path} to {self.config['hdf5_file']}")
+        self.log(f"ARLDM _prep_hdf5_file input from to {self.config['hdf5_file']}")
         
         cmd = [
             f"cd {self.config['arldm_path']}; echo Executing from directory `pwd`;",

--- a/builtin/builtin/data_stagein/pkg.py
+++ b/builtin/builtin/data_stagein/pkg.py
@@ -78,7 +78,22 @@ class DataStagein(Application):
         :param kwargs: Configuration parameters for this pkg.
         :return: None
         """
+        # Convert user_data_paths to list
+        try:
+            user_data_paths = self.config['user_data_paths']
+            if user_data_paths is not None:
+                self.user_data_list = user_data_paths.split(',')
+        except KeyError:
+            self.user_data_list = []
         
+        try:
+            # Convert mkdir_datapaths to list
+            mkdir_datapaths = self.config['mkdir_datapaths']
+            if mkdir_datapaths is not None:
+                self.mkdir_datapaths_list = mkdir_datapaths.split(',')
+        except KeyError:
+            self.mkdir_datapaths_list = []
+
         self.log(f"user_data_list: {self.user_data_list}")
         self.log(f"mkdir_datapaths_list: {self.mkdir_datapaths_list}")
         

--- a/builtin/builtin/ddmd/README.md
+++ b/builtin/builtin/ddmd/README.md
@@ -171,7 +171,7 @@ module load ddmd
 
 Store the current environment in the pipeline.
 ```bash
-jarvis pipeline env build
+jarvis pipeline env build +CONDA_OPENMM +CONDA_PYTORCH +DDMD_PATH
 ```
 
 ## 2.5. Add pkgs to the Pipeline
@@ -267,7 +267,7 @@ jarvis pipeline create hermes_ddmd_test
 
 Store the current environment in the pipeline.
 ```bash
-jarvis pipeline env build
+jarvis pipeline env build +CONDA_OPENMM +CONDA_PYTORCH +DDMD_PATH
 ```
 
 ## 4.5. Add pkgs to the Pipeline
@@ -345,7 +345,7 @@ module load ddmd
 
 Store the current environment in the pipeline.
 ```bash
-jarvis pipeline env build
+jarvis pipeline env build +CONDA_OPENMM +CONDA_PYTORCH +DDMD_PATH
 ```
 
 

--- a/builtin/builtin/pyflextrkr/README.md
+++ b/builtin/builtin/pyflextrkr/README.md
@@ -93,26 +93,28 @@ conda deactivate
 
 
 # 2. Running Pyflextrkr
-
+Example is using `TEST_NAME=run_mcs_tbpfradar3d_wrf` (only supported with dataset download).
 ## 2.1. Setup Environment
 Currently setup input path in a shared storage, below is a example on Ares cluster.
 ```bash
-EXPERIMENT_PATH=~/experiments/flextrkr_run # NFS
-INPUT_PATH=$EXPERIMENT_PATH/input_data/run_mcs_tbpfradar3d_wrf # NFS
-mkdir -p $INPUT_PATH
-OUTPUT_PATH=$EXPERIMENT_PATH/output_data
-mkdir -p $OUTPUT_PATH
+TEST_NAME=run_mcs_tbpfradar3d_wrf
+EXPERIMENT_PATH=~/experiments/pyflex_run # NFS
+
+export EXPERIMENT_INPUT_PATH=$EXPERIMENT_PATH/input_data # NFS
+scspkg env set pyflextrkr EXPERIMENT_INPUT_PATH=$EXPERIMENT_INPUT_PATH
+mkdir -p $EXPERIMENT_INPUT_PATH
 ```
 
 ## 2.2. Download Input Data
 Setup example input data `wrf_tbradar.tar.gz` and path.to `run_mcs_tbpfradar3d_wrf.tar.gz`
 ```bash
-wget https://portal.nersc.gov/project/m1867/PyFLEXTRKR/sample_data/tb_radar/wrf_tbradar.tar.gz -O ${INPUT_PATH}/run_mcs_tbpfradar3d_wrf.tar.gz
-
-tar -xvzf ${INPUT_PATH}/run_mcs_tbpfradar3d_wrf.tar.gz -C ${INPUT_PATH}
+cd $EXPERIMENT_INPUT_PATH
+wget https://portal.nersc.gov/project/m1867/PyFLEXTRKR/sample_data/tb_radar/wrf_tbradar.tar.gz -O $TEST_NAME.tar.gz
+mkdir $TEST_NAME
+tar -xvzf $TEST_NAME.tar.gz -C $TEST_NAME
 
 # Remove downloaded tar file
-rm -fv ${INPUT_PATH}/run_mcs_tbpfradar3d_wrf.tar.gz
+rm -rf $EXPERIMENT_INPUT_PATH/$TEST_NAME.tar.gz
 ```
 
 
@@ -153,7 +155,7 @@ module load pyflextrkr
 
 Store the current environment in the pipeline.
 ```bash
-jarvis pipeline env build
+jarvis pipeline env build +PYFLEXTRKR_PATH +EXPERIMENT_INPUT_PATH
 ```
 
 ## 2.6. Add pkgs to the Pipeline
@@ -161,18 +163,13 @@ jarvis pipeline env build
 
 Create a Jarvis pipeline with Pyflextrkr.
 ```bash
-jarvis pipeline append pyflextrkr runscript=run_mcs_tbpfradar3d_wrf pyflextrkr_path="`scspkg pkg src pyflextrkr`/PyFLEXTRKR"
+jarvis pipeline append pyflextrkr runscript=run_mcs_tbpfradar3d_wrf
 ```
 
-<!-- ```bash
-jarvis pipeline append pyflextrkr conda_env=flextrkr runscript=run_mcs_tbpfradar3d_wrf pyflextrkr_path="`scspkg pkg src pyflextrkr`/PyFLEXTRKR"
-
-jarvis pkg configure pyflextrkr conda_env=flextrkr runscript=run_mcs_tbpfradar3d_wrf config=${HOME}/jarvis-cd/builtin/builtin/pyflextrkr/example_config/run_mcs_tbpfradar3d_wrf_template.yml
-``` -->
 
 ## 2.7. Run Experiment
 
-Run the experiment
+Run the experiment, output are generated in `$EXPERIMENT_INPUT_PATH/output_data`.
 ```bash
 jarvis pipeline run
 ```
@@ -265,7 +262,7 @@ jarvis pipeline create hermes_pyflextrkr_test
 
 Store the current environment in the pipeline.
 ```bash
-jarvis pipeline env build
+jarvis pipeline env build +PYFLEXTRKR_PATH
 ```
 
 ## 4.5. Add pkgs to the Pipeline
@@ -275,12 +272,12 @@ and pyflextrkr (must use `flush_mode=sync` to prevent [this error](#oserror-log)
 ```bash
 jarvis pipeline append hermes_run --sleep=10 include=$EXPERIMENT_PATH flush_mode=sync
 jarvis pipeline append hermes_api +vfd
-jarvis pipeline append pyflextrkr runscript=run_mcs_tbpfradar3d_wrf pyflextrkr_path="`scspkg pkg src pyflextrkr`/PyFLEXTRKR" update_envar=true
+jarvis pipeline append pyflextrkr runscript=$TEST_NAME update_envar=true
 ```
 
 ## 4.6. Run the Experiment
 
-Run the experiment
+Run the experiment, output are generated in `$EXPERIMENT_INPUT_PATH/output_data`.
 ```bash
 jarvis pipeline run
 ```
@@ -299,15 +296,19 @@ For cluster that has node local storage, you can stagein data from shared storag
 
 ## 5.1 Setup Environment
 Currently setup DEFAULT input path in a shared storage, below is a example on Ares cluster using node local nvme.
-```bash
-RUN_SCRIPT=run_mcs_tbpfradar3d_wrf
-EXPERIMENT_PATH=~/experiments/flextrkr_run # NFS
-INPUT_PATH=$EXPERIMENT_PATH/input_data # NFS
-mkdir -p $INPUT_PATH
 
-LOCAL_EXPERIMENT_PATH=/mnt/nvme/$USER/flextrkr_run
+
+The shared storage path is same as before:
+```bash
+export TEST_NAME=run_mcs_tbpfradar3d_wrf
+EXPERIMENT_PATH=~/experiments/pyflex_run # NFS
+EXPERIMENT_INPUT_PATH=$EXPERIMENT_PATH/input_data # NFS
+mkdir -p $EXPERIMENT_INPUT_PATH
+```
+Setup the node local experiment paths:
+```bash
+LOCAL_EXPERIMENT_PATH=/mnt/nvme/$USER/pyflex_run
 LOCAL_INPUT_PATH=$LOCAL_EXPERIMENT_PATH/input_data
-LOCAL_OUTPUT_PATH=$LOCAL_EXPERIMENT_PATH/output_data
 ```
 
 ## 5.2. Download Input Data
@@ -334,25 +335,25 @@ module load pyflextrkr
 
 Store the current environment in the pipeline.
 ```bash
-jarvis pipeline env build
+jarvis pipeline env build +PYFLEXTRKR_PATH
 ```
 
 ## 5.6. Add pkgs to the Pipeline
 Add data_stagein to pipeline before pyflextrkr.
 ```bash 
 jarvis pipeline append data_stagein dest_data_path=$LOCAL_INPUT_PATH \
-user_data_paths=$INPUT_PATH/$RUN_SCRIPT \
-mkdir_datapaths=$LOCAL_INPUT_PATH,$LOCAL_OUTPUT_PATH
+user_data_paths=$EXPERIMENT_INPUT_PATH/$TEST_NAME \
+mkdir_datapaths=$LOCAL_INPUT_PATH
 ```
 
 Create a Jarvis pipeline with Pyflextrkr.
 ```bash
-jarvis pipeline append pyflextrkr runscript=run_mcs_tbpfradar3d_wrf pyflextrkr_path="`scspkg pkg src pyflextrkr`/PyFLEXTRKR" local_exp_dir=$LOCAL_EXPERIMENT_PATH
+jarvis pipeline append pyflextrkr runscript=$TEST_NAME local_exp_dir=$LOCAL_INPUT_PATH
 ```
 
 ## 5.7. Run the Experiment
 
-Run the experiment
+Run the experiment, output are generated in `$EXPERIMENT_INPUT_PATH/output_data`.
 ```bash
 jarvis pipeline run
 ```
@@ -370,25 +371,24 @@ jarvis pipeline clean
 Every step the same as [Pyflextrkr + Hermes](#4-pyflextrkr--hermes), except for when creating a Jarvis pipeline with Hermes, using the Hermes VFD interceptor:
 ```bash
 # Setup env
-RUN_SCRIPT=run_mcs_tbpfradar3d_wrf
-EXPERIMENT_PATH=~/experiments/flextrkr_run # NFS
+TEST_NAME=run_mcs_tbpfradar3d_wrf
+EXPERIMENT_PATH=~/experiments/pyflex_run # NFS
 INPUT_PATH=$EXPERIMENT_PATH/input_data # NFS
-mkdir -p $INPUT_PATH
+mkdir -p $EXPERIMENT_INPUT_PATH
 
-LOCAL_EXPERIMENT_PATH=/mnt/nvme/$USER/flextrkr_run
+LOCAL_EXPERIMENT_PATH=/mnt/nvme/$USER/pyflex_run
 LOCAL_INPUT_PATH=$LOCAL_EXPERIMENT_PATH/input_data
-LOCAL_OUTPUT_PATH=$LOCAL_EXPERIMENT_PATH/output_data
 
 # add pkg to pipeline
 jarvis pipeline append data_stagein dest_data_path=$LOCAL_INPUT_PATH \
-user_data_paths=$INPUT_PATH/$RUN_SCRIPT \
-mkdir_datapaths=$LOCAL_INPUT_PATH,$LOCAL_OUTPUT_PATH
+user_data_paths=$EXPERIMENT_INPUT_PATH/$TEST_NAME \
+mkdir_datapaths=$LOCAL_INPUT_PATH
 
 jarvis pipeline append hermes_run --sleep=10 include=$LOCAL_EXPERIMENT_PATH
 
 jarvis pipeline append hermes_api +vfd
 
-jarvis pipeline append pyflextrkr runscript=$RUN_SCRIPT pyflextrkr_path="`scspkg pkg src pyflextrkr`/PyFLEXTRKR" update_envar=true local_exp_dir=$LOCAL_EXPERIMENT_PATH
+jarvis pipeline append pyflextrkr runscript=$TEST_NAME update_envar=true local_exp_dir=$LOCAL_INPUT_PATH
 ```
 
 
@@ -404,7 +404,7 @@ free(): invalid size
 2024-01-03 18:49:07,944 - distributed.worker - WARNING - Compute Failed
 Key:       idclouds_tbpf-0bb7839d-ac6e-4e51-b309-ec2bc6667641
 Function:  execute_task
-args:      ((<function idclouds_tbpf at 0x7fce75d6da80>, '/home/mtang11/experiments/flextrkr_runs/input_data/run_mcs_tbpfradar3d_wrf/wrfout_rainrate_tb_zh_mh_2015-05-06_04:00:00.nc', (<class 'dict'>, [['ReflThresh_lowlevel_gap', 20.0], ['abs_ConvThres_aml', 45.0], ['absolutetb_threshs', [160, 330]], ['area_thresh', 36], ['background_Box', 12.0], ['clouddata_path', '/home/mtang11/experiments/flextrkr_runs/input_data/run_mcs_tbpfradar3d_wrf/'], ['clouddatasource', 'model'], ['cloudidmethod', 'label_grow'], ['cloudtb_cloud', 261.0], ['cloudtb_cold', 241.0], ['cloudtb_core', 225.0], ['cloudtb_warm', 261.0], ['col_peakedness_frac', 0.3], ['dask_tmp_dir', '/tmp/pyflextrkr_test'], ['databasename', 'wrfout_rainrate_tb_zh_mh_'], ['datatimeresolution', 1.0], ['dbz_lowlevel_asl', 2.0], ['dbz_thresh', 10], ['duration_range', [2, 300]], ['echotop_gap', 1], ['enddate', '20150506.1600'], ['etop25dBZ_Thresh', 10.0], ['feature_type', 'tb_pf_radar3d'], ['feature_varname', 'feature_number'], ['featuresize_varname',
+args:      ((<function idclouds_tbpf at 0x7fce75d6da80>, '/home/mtang11/experiments/pyflex_runs/input_data/run_mcs_tbpfradar3d_wrf/wrfout_rainrate_tb_zh_mh_2015-05-06_04:00:00.nc', (<class 'dict'>, [['ReflThresh_lowlevel_gap', 20.0], ['abs_ConvThres_aml', 45.0], ['absolutetb_threshs', [160, 330]], ['area_thresh', 36], ['background_Box', 12.0], ['clouddata_path', '/home/mtang11/experiments/pyflex_runs/input_data/run_mcs_tbpfradar3d_wrf/'], ['clouddatasource', 'model'], ['cloudidmethod', 'label_grow'], ['cloudtb_cloud', 261.0], ['cloudtb_cold', 241.0], ['cloudtb_core', 225.0], ['cloudtb_warm', 261.0], ['col_peakedness_frac', 0.3], ['dask_tmp_dir', '/tmp/pyflextrkr_test'], ['databasename', 'wrfout_rainrate_tb_zh_mh_'], ['datatimeresolution', 1.0], ['dbz_lowlevel_asl', 2.0], ['dbz_thresh', 10], ['duration_range', [2, 300]], ['echotop_gap', 1], ['enddate', '20150506.1600'], ['etop25dBZ_Thresh', 10.0], ['feature_type', 'tb_pf_radar3d'], ['feature_varname', 'feature_number'], ['featuresize_varname',
 kwargs:    {}
 Exception: "OSError('Unable to synchronously open file (file signature not found)')"
 

--- a/builtin/builtin/pyflextrkr/README.md
+++ b/builtin/builtin/pyflextrkr/README.md
@@ -353,7 +353,7 @@ jarvis pipeline append pyflextrkr runscript=$TEST_NAME local_exp_dir=$LOCAL_INPU
 
 ## 5.7. Run the Experiment
 
-Run the experiment, output are generated in `$EXPERIMENT_INPUT_PATH/output_data`.
+Run the experiment, output are generated in `$LOCAL_INPUT_PATH/output_data`.
 ```bash
 jarvis pipeline run
 ```

--- a/builtin/builtin/pyflextrkr/example_config/run_mcs_tbpfradar3d_wrf_template.yml
+++ b/builtin/builtin/pyflextrkr/example_config/run_mcs_tbpfradar3d_wrf_template.yml
@@ -23,9 +23,9 @@ timeout: 360  # [seconds] Dask timeout limit
 
 # Start/end date and time
 startdate: '20150506.0000'
-enddate: '20150506.1600' # smallest possible to run all processing steps
+enddate: '20150506.1600' # 17 files, each ~15-17 MB
 # enddate: '20150506.0800' # smallest possible to run all processing steps
-# enddate: '20150510.0000' # largest possible to run all processing steps
+# enddate: '20150510.0000' # 97 files, total 1.4GB
 
 # Specify tracking input data date/time string format
 # This is the preprocessed file that contains Tb & rainrate

--- a/builtin/builtin/pyflextrkr/example_config/run_mcs_tbpfradar3d_wrf_template.yml
+++ b/builtin/builtin/pyflextrkr/example_config/run_mcs_tbpfradar3d_wrf_template.yml
@@ -24,7 +24,7 @@ timeout: 360  # [seconds] Dask timeout limit
 # Start/end date and time
 startdate: '20150506.0000'
 enddate: '20150506.1600' # 17 files, each ~15-17 MB
-# enddate: '20150506.0800' # smallest possible to run all processing steps
+# enddate: '20150506.0800' # 9 files, smallest possible to run all processing steps
 # enddate: '20150510.0000' # 97 files, total 1.4GB
 
 # Specify tracking input data date/time string format

--- a/builtin/builtin/pyflextrkr/pkg.py
+++ b/builtin/builtin/pyflextrkr/pkg.py
@@ -74,10 +74,10 @@ class Pyflextrkr(Application):
                 'default': None,
             },
             {
-                'name': 'experiment_path',
+                'name': 'experiment_input_path',
                 'msg': 'Absolute path to the experiment run input and output files',
                 'type': str,
-                'default': '${HOME}/experiments/flextrkr_runs',
+                'default': None,
             },
             {
                 'name': 'run_parallel',
@@ -119,9 +119,11 @@ class Pyflextrkr(Application):
         :return: None
         """
         
-        if self.config['experiment_path'] is not None:
-            self.config['experiment_path'] = os.path.expandvars(self.config['experiment_path'])
-            self.env['EXPERIMENT_PATH'] = self.config['experiment_path']
+        experiment_input_path = os.getenv('EXPERIMENT_INPUT_PATH')
+        if experiment_input_path is None:
+            raise Exception("Must set the experiment_input_path")
+        else:
+            self.config['experiment_input_path'] = experiment_input_path
         
         # update config file everytime
         self.config['config'] = f"{self.pkg_dir}/example_config/{self.config['runscript']}_template.yml"
@@ -187,12 +189,12 @@ class Pyflextrkr(Application):
         
         with open(yaml_file, "r") as stream:
             
-            experiment_path = self.config['experiment_path']
+            experiment_input_path = self.config['experiment_input_path']
             if self.config['local_exp_dir'] is not None:
-                experiment_path = self.config['local_exp_dir']
+                experiment_input_path = self.config['local_exp_dir']
             
-            input_path = f"{experiment_path}/input_data/{self.config['runscript']}/"
-            output_path = f"{experiment_path}/output_data/{self.config['runscript']}/"
+            input_path = f"{experiment_input_path}/{self.config['runscript']}/"
+            output_path = f"{experiment_input_path}/output_data/{self.config['runscript']}/"
             
             pathlib.Path(input_path).mkdir(parents=True, exist_ok=True)
             pathlib.Path(output_path).mkdir(parents=True, exist_ok=True)
@@ -267,7 +269,7 @@ class Pyflextrkr(Application):
                 Exec(cmd, LocalExecInfo(env=self.mod_env,))
             
         except Exception as e:
-            self._unset_vfd_vars()
+            self._unset_vfd_vars(env_vars_toset)
         
     
     def _construct_cmd(self):
@@ -385,9 +387,9 @@ class Pyflextrkr(Application):
 
         :return: None
         """
-        # self.log(f"Manual Exec Required: Please clean up files in {self.config['experiment_path']}")
+        # self.log(f"Manual Exec Required: Please clean up files in {self.config['experiment_input_path']}")
         
-        output_dir = self.config['experiment_path'] + f"/output_data/{self.config['runscript']}"
+        output_dir = self.config['experiment_input_path'] + f"/output_data/{self.config['runscript']}"
         if self.config['local_exp_dir'] is not None:
             output_dir = self.config['local_exp_dir'] + f"/output_data/{self.config['runscript']}"
         


### PR DESCRIPTION
Update dev to main. 

## For both `arldm` and `pyflextrkr` apps:
Mainly fixed to use`EXPERIMENT_INPUT_PATH` as the main input dataset path, default all data output to `EXPERIMENT_INPUT_PATH /output_data`. Or if node local path is used, output are default to `LOCAL_INPUT_PATH/output_data`.

## For `ddmd` app:
Paths are not updated yet, still need to update for paths and test run with Hermes.